### PR TITLE
release-schema.json: add accessDetailsURL and unofficialTranslation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ Use cases include:
 * Checking whether authors are involved in other ways in the contracting process, e.g. as bidders
 * Measuring the accessibility of documents
 
-## Legal context
-
-In the European Union, this extension's fields correspond to [eforms BG-101 (Procurement documents)](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/). For correspondences to eForms fields, see [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
-
 ## Example
 
 ```json

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Indicate the page numbers at which relevant information can be found within a large document
 * Describe any special arrangements needed to access the document
 * Name the author of the document (not to be confused with its publisher)
-* Indicate if the document is an unofficial translation
+* Indicate whether the document is an unofficial translation
 
 Use cases include:
 
@@ -46,7 +46,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2023-04-05
 
-* Add `accessDetailsURL` and `unofficialTranslation`.
+* Add `accessDetailsURL` and `unofficialTranslation` fields.
 
 ### 2020-04-24
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,17 @@
 * Indicate the page numbers at which relevant information can be found within a large document
 * Describe any special arrangements needed to access the document
 * Name the author of the document (not to be confused with its publisher)
+* Indicate if the document is an unofficial translation
 
 Use cases include:
 
 * Accessing the document and locating the information within it
 * Checking whether authors are involved in other ways in the contracting process, e.g. as bidders
 * Measuring the accessibility of documents
+
+## Legal context
+
+In the European Union, this extension's fields correspond to [eforms BG-101 (Procurement documents)](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/). For correspondences to eForms fields, see [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
 
 ## Example
 
@@ -24,9 +29,12 @@ Use cases include:
         "title": "Equity transfer cap terms",
         "description": "No equity transfer is permitted until construction is completed. See document for more details.",
         "url": "http://example.com/ppp_unit/documents/contracts/4g_network_signed_contract.pdf",
+        "language": "en",
+        "unofficialTranslation": false,
         "pageStart": "334",
         "pageEnd": "336",
-        "accessDetails": "You must register for document access via the following url: http://example.com/ppp_unit/registration/",
+        "accessDetails": "This document can only be accessed by visiting the PPP unit office by appointment. Please see the PPP unit website for further details.",
+        "accessDetailsURL": "http://example.com/ppp_unit/registration/",
         "author": "Contract department, PPP unit"
       }
     ]
@@ -39,6 +47,10 @@ Use cases include:
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2023-04-05
+
+* Add `accessDetailsURL` and `unofficialTranslation`.
 
 ### 2020-04-24
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -31,7 +31,7 @@
         },
         "accessDetailsURL": {
           "title": "Access details",
-          "description": "A web address containg a description of any special arrangements needed to access the document.",
+          "description": "A web address with information on any special arrangements needed to access the document.",
           "type": [
             "string",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -29,6 +29,15 @@
           ],
           "minLength": 1
         },
+        "accessDetailsURL": {
+          "title": "Access details",
+          "description": "A web address containg a description of any special arrangements needed to access the document.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
         "author": {
           "title": "Author",
           "description": "The names of the authors of the document.",
@@ -37,6 +46,14 @@
             "null"
           ],
           "minLength": 1
+        },
+        "unofficialTranslation": {
+          "title": "Unofficial translation",
+          "description": "A true/false field to indicate if the language of the document is an unofficial translation.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     }

--- a/release-schema.json
+++ b/release-schema.json
@@ -30,8 +30,8 @@
           "minLength": 1
         },
         "accessDetailsURL": {
-          "title": "Access details",
-          "description": "A web address with information on any special arrangements needed to access the document.",
+          "title": "Access details URL",
+          "description": "A web address for information on any special arrangements needed to access the document.",
           "type": [
             "string",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -49,7 +49,7 @@
         },
         "unofficialTranslation": {
           "title": "Unofficial translation",
-          "description": "A true/false field to indicate if the language of the document is an unofficial translation.",
+          "description": "Whether the document is an unofficial translation.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
In the example I used a field that will be deprecated in 1.2 so that the tests would pass, not sure if that should be changed to the 1.2 field instead (`language` vs `languages`)